### PR TITLE
Fix typings

### DIFF
--- a/docs/ionic.rst
+++ b/docs/ionic.rst
@@ -42,7 +42,7 @@ To setup Sentry in your codebase add this to your ``app.module.ts``:
 
     import * as Sentry from 'sentry-cordova';
 
-    Sentry.create({ '___DSN___' });
+    Sentry.create({ dsn: '___DSN___' });
 
 In order to also use the Ionic provided ``IonicErrorHandler`` we need to add
 ``SentryIonicErrorHandler``:

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "sentry-cordova",
   "version": "0.8.3",
   "main": "dist/js/sentry-cordova.js",
+  "types": "dist/js/sentry-cordova.d.ts",
   "license": "MIT",
   "repository": "git://github.com/getsentry/sentry-cordova.git",
   "cordova": {


### PR DESCRIPTION
Fix *Could not find a declaration file for module 'sentry-cordova'* error when attempting to import Sentry into a TypeScript project, and fix a typo in the Ionic setup docs.