### PR TITLE
fix: call native install with DSN password

### DIFF
--- a/src/js/backend.ts
+++ b/src/js/backend.ts
@@ -102,7 +102,7 @@ export class CordovaBackend implements Backend {
     if (this.frontend.getDSN()) {
       this.nativeCall(
         'install',
-        this.frontend.getDSN()!.toString(),
+        this.frontend.getDSN()!.toString(true),
         this.frontend.getOptions(),
       );
     }


### PR DESCRIPTION
The native install must be called with the full DSN including password.

Note that without the password the native install fails silently, and the error (*Invalid DSN, the following properties aren't set '[secret key]'*) is swallowed.