### PR TITLE
Remove usage of deprecated requireCordovaModule

### DIFF
--- a/scripts/before_compile.js
+++ b/scripts/before_compile.js
@@ -5,8 +5,8 @@ module.exports = function(ctx) {
     } - set SENTRY_SKIP_AUTO_RELEASE=true to skip this`
   );
   const SentryCli = require('@sentry/cli');
-  const path = ctx.requireCordovaModule('path');
-  const fs = ctx.requireCordovaModule('fs');
+  const path = require('path');
+  const fs = require('fs');
   const crypto = require('crypto');
 
   if (process.env.SENTRY_SKIP_AUTO_RELEASE) {

--- a/scripts/plugin_add_rm.js
+++ b/scripts/plugin_add_rm.js
@@ -9,8 +9,7 @@ module.exports = function(ctx) {
     `Sentry: running ${ctx.hook} - set SENTRY_SKIP_WIZARD=true to skip this`
   );
   const wizard = require('@sentry/wizard');
-  const tty = require('tty');
-  const fs = ctx.requireCordovaModule('fs');
+  const fs = require('fs');
 
   let uninstall = false;
 


### PR DESCRIPTION
The usage of `requireCordovaModule` is deprecated and throws an error when used for requiring non `codova-` modules.

This change was introduced with `cordova>=9`.

See: https://github.com/apache/cordova-lib/pull/707