### PR TITLE
include source files with dot-separated names

### DIFF
--- a/scripts/before_compile.js
+++ b/scripts/before_compile.js
@@ -66,9 +66,9 @@ module.exports = function(ctx) {
     let includes = [];
     walk(buildPath).forEach((file, index) => {
       let f = path.basename(file);
-      let [name, ext1, ext2] = f.split('.');
+      let [ext2, ext1, name] = f.split('.').reverse();
       // we only want js source files and the according sourcemaps (no css etc.)
-      if (ext1 === 'js' || (ext1 === 'js' && ext2 === 'map')) {
+      if (ext2 === 'js' || (ext1 === 'js' && ext2 === 'map')) {
         // ignore sw-toolbox file
         if (name !== 'sw-toolbox') {
           includes.push(file);


### PR DESCRIPTION
I figured out that Sentry wasn't getting our sourcemap because it was excluding our main bundle file.

```
appname.bundle.js
appname.bundle.js.map
```

The reason is that the includes walker assumes the main filename does not use a dot seaprator. It would parse *bundle* and *js* but never the *map* extension. It would also assume the main file extension was *bundle* in the example above.

This change reverses the array of filename _parts_, starting with the last extension, ensuring extensions are not overlooked. It does nothing to ensure the *name* part is complete because it is only used to exclude a single specific file.

After this change I noticed that one of my plugins was also being excluded from the upload becuase it too had a dot in the filename.

