### PR TITLE
fix: correct missing 'paths' element in before_compile context options

### DIFF
--- a/scripts/before_compile.js
+++ b/scripts/before_compile.js
@@ -45,7 +45,10 @@ module.exports = function(ctx) {
   const ignore = ['node_modules'];
   const sentryCli = new SentryCli(configFile);
 
-  const allReleases = ctx.opts.paths.map(buildPath => {
+  const projectRoot = ctx.opts.projectRoot || '';
+  const buildPaths = ctx.opts.platforms.map(p => path.join(projectRoot, 'platforms', p, 'www'));
+
+  const allReleases = buildPaths.map(buildPath => {
     if (!fs.existsSync(buildPath)) {
       console.error(`Sentry: build path does not exist ${buildPath}`);
       console.error('This is not an Ionic project, please check out:');


### PR DESCRIPTION
If `cordova prepare` and `cordova compile` are run independently, the paths array generated by prepare is not passed on to compile, and therefore not available to the `before_compile` script. This is normally not an issue if the user runs `cordova build` which runs prepare and compile in a promise chain with the same options object.

closes issue #122