### PR TITLE
fix: replicate cordova prepare functionality for getting platform paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "@sentry/minimal": "~5.6.1",
     "@sentry/types": "~5.6.1",
     "@sentry/utils": "~5.6.1",
-    "@sentry/wizard": "^1.0.0"
+    "@sentry/wizard": "^1.0.0",
+    "cordova-lib": "^9.0.1"
   },
   "devDependencies": {
     "@sentry/typescript": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "@sentry/minimal": "~5.6.1",
     "@sentry/types": "~5.6.1",
     "@sentry/utils": "~5.6.1",
-    "@sentry/wizard": "^1.0.0",
-    "cordova-lib": "^9.0.1"
+    "@sentry/wizard": "^1.0.0"
   },
   "devDependencies": {
     "@sentry/typescript": "^5.3.0",

--- a/scripts/before_compile.js
+++ b/scripts/before_compile.js
@@ -46,7 +46,8 @@ module.exports = function(ctx) {
   const sentryCli = new SentryCli(configFile);
 
   const buildPaths = ctx.opts.paths || ctx.opts.platforms.map(p => {
-    const PlatformApi = require(`platforms/${p}/cordova/Api.js`);
+    const apiPath = path.join('platforms', p, 'cordova', 'Api.js');
+    const PlatformApi = require(apiPath);
     const platformApi = new PlatformApi();
     return platformApi.getPlatformInfo().locations.www;
   });

--- a/scripts/before_compile.js
+++ b/scripts/before_compile.js
@@ -1,7 +1,7 @@
-module.exports = function (ctx) {
+module.exports = function(ctx) {
   console.log(
     `Sentry: running ${
-    ctx.hook
+      ctx.hook
     } - set SENTRY_SKIP_AUTO_RELEASE=true to skip this`
   );
   const SentryCli = require('@sentry/cli');
@@ -46,17 +46,11 @@ module.exports = function (ctx) {
   const sentryCli = new SentryCli(configFile);
 
   const buildPaths = ctx.opts.paths || ctx.opts.platforms.map(p => {
-    // `require` needs absolute file path to prevent "Cannot find module", and
-    // working directory is set to project root by upstream tools.
-    const apiPath = path.join(process.cwd(), 'platforms', p, 'cordova', 'Api.js');
-    if (!fs.existsSync(apiPath)) {
-      console.error(`Sentry: unable to locate build path for platform '${p}'`);
-      return
-    }
+    const apiPath = path.join('platforms', p, 'cordova', 'Api.js');
     const PlatformApi = require(apiPath);
     const platformApi = new PlatformApi();
     return platformApi.getPlatformInfo().locations.www;
-  }).filter(x => x);
+  });
 
   const allReleases = buildPaths.map(buildPath => {
     if (!fs.existsSync(buildPath)) {
@@ -105,52 +99,52 @@ module.exports = function (ctx) {
     let release = Promise.resolve(fileHash.slice(0, 20));
     // if the environment variable SENTRY_RELEASE_STRING is set this will be used instead of the filehash slice
     if (process.env.SENTRY_RELEASE_STRING) {
-      release = Promise.resolve(process.env.SENTRY_RELEASE_STRING);
+        release = Promise.resolve(process.env.SENTRY_RELEASE_STRING);
     } else if (process.env.SENTRY_RELEASE_PROPOSE_VERSION) {
-      release = sentryCli.releases.proposeVersion();
+        release = sentryCli.releases.proposeVersion();
     }
 
     return release.then(
-      release => {
-        const regex = /<head>(?:[\s\S]*(<!-- sentry-cordova -->))?/g;
-        let contents = fs.readFileSync(indexHtml, {
-          encoding: 'utf-8',
-        });
-        const releaseSentry = `
+        release => {
+            const regex = /<head>(?:[\s\S]*(<!-- sentry-cordova -->))?/g;
+            let contents = fs.readFileSync(indexHtml, {
+                encoding: 'utf-8',
+            });
+            const releaseSentry = `
     <script>
     (function(w){var i=w.SENTRY_RELEASE=w.SENTRY_RELEASE||{};i.id='${release}';})(this);
     </script>
     <!-- sentry-cordova -->`;
-        const replaceWith = `<head>${releaseSentry}`;
-        fs.writeFileSync(indexHtml, contents.replace(regex, replaceWith));
+            const replaceWith = `<head>${releaseSentry}`;
+            fs.writeFileSync(indexHtml, contents.replace(regex, replaceWith));
 
-        // This is allowed to fail because it's ionic specific
-        const projectRootIndexHtml = path.join(
-          ctx.opts.projectRoot,
-          'src',
-          'index.html'
-        );
-        if (fs.existsSync(projectRootIndexHtml)) {
-          contents = fs.readFileSync(projectRootIndexHtml, {
-            encoding: 'utf-8',
-          });
-          fs.writeFileSync(
-            projectRootIndexHtml,
-            contents.replace(regex, replaceWith)
-          );
+            // This is allowed to fail because it's ionic specific
+            const projectRootIndexHtml = path.join(
+                ctx.opts.projectRoot,
+                'src',
+                'index.html'
+            );
+            if (fs.existsSync(projectRootIndexHtml)) {
+                contents = fs.readFileSync(projectRootIndexHtml, {
+                    encoding: 'utf-8',
+                });
+                fs.writeFileSync(
+                    projectRootIndexHtml,
+                    contents.replace(regex, replaceWith)
+                );
+            }
+
+            console.log(`Uploading assets release: '${release}' path: ${buildPath}`);
+            return sentryCli.releases
+                .new(release)
+                .then(() =>
+                    sentryCli.releases.uploadSourceMaps(release, {
+                        include: includes,
+                        ignore: ignore,
+                    })
+                )
+                .then(() => sentryCli.releases.finalize(release));
         }
-
-        console.log(`Uploading assets release: '${release}' path: ${buildPath}`);
-        return sentryCli.releases
-          .new(release)
-          .then(() =>
-            sentryCli.releases.uploadSourceMaps(release, {
-              include: includes,
-              ignore: ignore,
-            })
-          )
-          .then(() => sentryCli.releases.finalize(release));
-      }
     )
   });
 

--- a/scripts/before_compile.js
+++ b/scripts/before_compile.js
@@ -1,3 +1,5 @@
+const platforms = require('cordova-lib').cordova_platforms
+
 module.exports = function(ctx) {
   console.log(
     `Sentry: running ${
@@ -45,8 +47,9 @@ module.exports = function(ctx) {
   const ignore = ['node_modules'];
   const sentryCli = new SentryCli(configFile);
 
-  const projectRoot = ctx.opts.projectRoot || '';
-  const buildPaths = ctx.opts.platforms.map(p => path.join(projectRoot, 'platforms', p, 'www'));
+  const buildPaths = ctx.opts.paths || ctx.opts.platforms.map(p => {
+    return platforms.getPlatformApi(p).getPlatformInfo().locations.www;
+  });
 
   const allReleases = buildPaths.map(buildPath => {
     if (!fs.existsSync(buildPath)) {

--- a/scripts/before_compile.js
+++ b/scripts/before_compile.js
@@ -1,7 +1,7 @@
-module.exports = function(ctx) {
+module.exports = function (ctx) {
   console.log(
     `Sentry: running ${
-      ctx.hook
+    ctx.hook
     } - set SENTRY_SKIP_AUTO_RELEASE=true to skip this`
   );
   const SentryCli = require('@sentry/cli');
@@ -46,11 +46,17 @@ module.exports = function(ctx) {
   const sentryCli = new SentryCli(configFile);
 
   const buildPaths = ctx.opts.paths || ctx.opts.platforms.map(p => {
-    const apiPath = path.join('platforms', p, 'cordova', 'Api.js');
+    // `require` needs absolute file path to prevent "Cannot find module", and
+    // working directory is set to project root by upstream tools.
+    const apiPath = path.join(process.cwd(), 'platforms', p, 'cordova', 'Api.js');
+    if (!fs.existsSync(apiPath)) {
+      console.error(`Sentry: unable to locate build path for platform '${p}'`);
+      return
+    }
     const PlatformApi = require(apiPath);
     const platformApi = new PlatformApi();
     return platformApi.getPlatformInfo().locations.www;
-  });
+  }).filter(x => x);
 
   const allReleases = buildPaths.map(buildPath => {
     if (!fs.existsSync(buildPath)) {
@@ -99,52 +105,52 @@ module.exports = function(ctx) {
     let release = Promise.resolve(fileHash.slice(0, 20));
     // if the environment variable SENTRY_RELEASE_STRING is set this will be used instead of the filehash slice
     if (process.env.SENTRY_RELEASE_STRING) {
-        release = Promise.resolve(process.env.SENTRY_RELEASE_STRING);
+      release = Promise.resolve(process.env.SENTRY_RELEASE_STRING);
     } else if (process.env.SENTRY_RELEASE_PROPOSE_VERSION) {
-        release = sentryCli.releases.proposeVersion();
+      release = sentryCli.releases.proposeVersion();
     }
 
     return release.then(
-        release => {
-            const regex = /<head>(?:[\s\S]*(<!-- sentry-cordova -->))?/g;
-            let contents = fs.readFileSync(indexHtml, {
-                encoding: 'utf-8',
-            });
-            const releaseSentry = `
+      release => {
+        const regex = /<head>(?:[\s\S]*(<!-- sentry-cordova -->))?/g;
+        let contents = fs.readFileSync(indexHtml, {
+          encoding: 'utf-8',
+        });
+        const releaseSentry = `
     <script>
     (function(w){var i=w.SENTRY_RELEASE=w.SENTRY_RELEASE||{};i.id='${release}';})(this);
     </script>
     <!-- sentry-cordova -->`;
-            const replaceWith = `<head>${releaseSentry}`;
-            fs.writeFileSync(indexHtml, contents.replace(regex, replaceWith));
+        const replaceWith = `<head>${releaseSentry}`;
+        fs.writeFileSync(indexHtml, contents.replace(regex, replaceWith));
 
-            // This is allowed to fail because it's ionic specific
-            const projectRootIndexHtml = path.join(
-                ctx.opts.projectRoot,
-                'src',
-                'index.html'
-            );
-            if (fs.existsSync(projectRootIndexHtml)) {
-                contents = fs.readFileSync(projectRootIndexHtml, {
-                    encoding: 'utf-8',
-                });
-                fs.writeFileSync(
-                    projectRootIndexHtml,
-                    contents.replace(regex, replaceWith)
-                );
-            }
-
-            console.log(`Uploading assets release: '${release}' path: ${buildPath}`);
-            return sentryCli.releases
-                .new(release)
-                .then(() =>
-                    sentryCli.releases.uploadSourceMaps(release, {
-                        include: includes,
-                        ignore: ignore,
-                    })
-                )
-                .then(() => sentryCli.releases.finalize(release));
+        // This is allowed to fail because it's ionic specific
+        const projectRootIndexHtml = path.join(
+          ctx.opts.projectRoot,
+          'src',
+          'index.html'
+        );
+        if (fs.existsSync(projectRootIndexHtml)) {
+          contents = fs.readFileSync(projectRootIndexHtml, {
+            encoding: 'utf-8',
+          });
+          fs.writeFileSync(
+            projectRootIndexHtml,
+            contents.replace(regex, replaceWith)
+          );
         }
+
+        console.log(`Uploading assets release: '${release}' path: ${buildPath}`);
+        return sentryCli.releases
+          .new(release)
+          .then(() =>
+            sentryCli.releases.uploadSourceMaps(release, {
+              include: includes,
+              ignore: ignore,
+            })
+          )
+          .then(() => sentryCli.releases.finalize(release));
+      }
     )
   });
 

--- a/scripts/before_compile.js
+++ b/scripts/before_compile.js
@@ -46,11 +46,17 @@ module.exports = function(ctx) {
   const sentryCli = new SentryCli(configFile);
 
   const buildPaths = ctx.opts.paths || ctx.opts.platforms.map(p => {
-    const apiPath = path.join('platforms', p, 'cordova', 'Api.js');
+    // `require` needs absolute file path to prevent "Cannot find module", and
+    // working directory is set to project root by upstream tools.
+    const apiPath = path.join(process.cwd(), 'platforms', p, 'cordova', 'Api.js');
+    if (!fs.existsSync(apiPath)) {
+      console.error(`Sentry: unable to locate build path for platform '${p}'`);
+      return
+    }
     const PlatformApi = require(apiPath);
     const platformApi = new PlatformApi();
     return platformApi.getPlatformInfo().locations.www;
-  });
+  }).filter(x => x);
 
   const allReleases = buildPaths.map(buildPath => {
     if (!fs.existsSync(buildPath)) {

--- a/scripts/before_compile.js
+++ b/scripts/before_compile.js
@@ -1,5 +1,3 @@
-const platforms = require('cordova-lib').cordova_platforms
-
 module.exports = function(ctx) {
   console.log(
     `Sentry: running ${
@@ -48,7 +46,9 @@ module.exports = function(ctx) {
   const sentryCli = new SentryCli(configFile);
 
   const buildPaths = ctx.opts.paths || ctx.opts.platforms.map(p => {
-    return platforms.getPlatformApi(p).getPlatformInfo().locations.www;
+    const PlatformApi = require(`platforms/${p}/cordova/Api.js`);
+    const platformApi = new PlatformApi();
+    return platformApi.getPlatformInfo().locations.www;
   });
 
   const allReleases = buildPaths.map(buildPath => {


### PR DESCRIPTION
Blindly using platforms/<platform>/www is not correct, as each platform can have the www folder in a different location. A more robust approach uses the platforms functionality of cordova-lib to obtain the path to the www folder.

This requires the cordova-lib NPM module, and I'm not familiar enough with the build process to know if this will work correctly when packaged for NPM (it does locally though).