### PR TITLE
Added Android SDK version config variable

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -9,6 +9,8 @@
     <repo>https://github.com/getsentry/sentry-cordova.git</repo>
     <issue>https://github.com/getsentry/sentry-cordova/issues</issue>
 
+    <preference name="SENTRY_ANDROID_SDK_VERSION" default="1+"/>
+
     <engines>
         <!-- https://issues.apache.org/jira/browse/CB-10239?jql=labels%20%3D%20cordova-8.0.0 -->
         <!-- Requires > 8.0.0 because of scoped npm packages -->
@@ -34,7 +36,7 @@
 
       <source-file src="src/android/io/sentry/SentryCordova.java" target-dir="src/io/sentry/" />
 
-      <framework src="io.sentry:sentry-android:1+" />
+      <framework src="io.sentry:sentry-android:$SENTRY_ANDROID_SDK_VERSION" />
     </platform>
 
     <!-- ios -->


### PR DESCRIPTION
If there is already more plugins in cordova project, it is useful to specify version in order to achieve each other compatibility.
I added config variable that allows to specify exact Sentry SDK version. It is possible to do that in config.xml like this:

    <plugin name="sentry-cordova" spec="^0.16.2">
        <variable name="SENTRY_ANDROID_SDK_VERSION" value="1.6.8" />
    </plugin>
