### PR TITLE
Add path to place sentry.properties

### DIFF
--- a/scripts/before_compile.js
+++ b/scripts/before_compile.js
@@ -38,7 +38,7 @@ module.exports = function(ctx) {
 
   const configFile = path.join('sentry.properties');
   if (!fs.existsSync(configFile)) {
-    console.error('Sentry: sentry.properties does not exist in project root!`');
+    console.error('Sentry: sentry.properties does not exist in project root! ' + ctx.opts.projectRoot);
     process.exit(1);
     return;
   }


### PR DESCRIPTION
This would have helped me know where to place the configuration
file while using Corber, a Cordova CLI.

I’m a near-novice in this realm so it may be that `ctx.opts.projectRoot` isn’t a reliable way to find what path to put the file at, but it worked for me, and I think it’s always nice to spell things out in this kind of situation.

Thanks for all the work on this! I ultimately found that any build I uploaded to TestFlight would open to a permanent blank screen so I switched to the JS-only version, but I couldn’t extract any logging or other helpful things that might facilitate debugging that problem, sadly.