### PR TITLE
Fix source map file generating error

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -24,6 +24,7 @@
     <js-module src="dist/js/sentry-cordova.bundle.js" name="Sentry">
         <clobbers target="Sentry" />
     </js-module>
+    <asset src="dist/js/sentry-cordova.bundle.js.map" target="plugins/sentry-cordova/dist/js/sentry-cordova.bundle.js.map" />
 
     <!-- android -->
     <platform name="android">


### PR DESCRIPTION
This properly copies source map file to the correct build directory.
Sorry, I could only test this in ios device. But should work in Android too.

Fixes #113
Fixes #163
Fixes #93 