### PR TITLE
build(android): Bump Android SDK to v4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 - build(internal): Switch to eslint
-- build(android): Bump Android SDK to v4.1.0
+- build(android): Bump Android SDK to v4.1.0 (#187)
 
 ## v0.17.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - build(internal): Switch to eslint
+- build(android): Bump Android SDK to v4.1.0
 
 ## v0.17.0
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -35,6 +35,11 @@
           </feature>
       </config-file>
 
+       <config-file target="AndroidManifest.xml" parent="/manifest/application">
+          <meta-data android:name="io.sentry.auto-init" android:value="false" />
+      </config-file>
+
+
       <source-file src="src/android/io/sentry/SentryCordova.java" target-dir="src/io/sentry/" />
 
       <framework src="io.sentry:sentry-android:$SENTRY_ANDROID_SDK_VERSION" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -9,7 +9,7 @@
     <repo>https://github.com/getsentry/sentry-cordova.git</repo>
     <issue>https://github.com/getsentry/sentry-cordova/issues</issue>
 
-    <preference name="SENTRY_ANDROID_SDK_VERSION" default="1+"/>
+    <preference name="SENTRY_ANDROID_SDK_VERSION" default="4.1.0"/>
 
     <engines>
         <!-- https://issues.apache.org/jira/browse/CB-10239?jql=labels%20%3D%20cordova-8.0.0 -->

--- a/src/android/io/sentry/SentryCordova.java
+++ b/src/android/io/sentry/SentryCordova.java
@@ -14,7 +14,8 @@ import android.util.Log;
 
 import java.util.Date;
 
-import io.sentry.android.AndroidSentryClientFactory;
+import io.sentry.android.core.SentryAndroid;
+import io.sentry.Sentry;
 
 public class SentryCordova extends CordovaPlugin {
   private static final String TAG = "Sentry";
@@ -27,7 +28,10 @@ public class SentryCordova extends CordovaPlugin {
   public boolean execute(String action, JSONArray args, final CallbackContext callbackContext) throws JSONException {
     if(action.equals("install")) {
       String dsn = args.getString(0);
-      Sentry.init(dsn, new AndroidSentryClientFactory(this.cordova.getActivity().getApplicationContext()));
+
+      SentryAndroid.init(this.cordova.getActivity().getApplicationContext(), options -> {
+        options.setDsn(dsn);
+      });
       // We need to return false here to not create the captureBreadcrumb hook
       callbackContext.sendPluginResult(new PluginResult(Status.OK, false));
     } else {

--- a/src/android/io/sentry/SentryCordova.java
+++ b/src/android/io/sentry/SentryCordova.java
@@ -15,7 +15,6 @@ import android.util.Log;
 import java.util.Date;
 
 import io.sentry.android.core.SentryAndroid;
-import io.sentry.Sentry;
 
 public class SentryCordova extends CordovaPlugin {
   private static final String TAG = "Sentry";


### PR DESCRIPTION
- Bumps Android SDK to v4.1.0
- Updates the call to init on the Android bridge
- Injects `auto-init` to be false to `AndroidManifest.xml`

Notes:
Bumps Android but we still send the event through the `BrowserBackend` and only send events through the native layer on iOS.

Addresses #185


Testing:
Tested on a simple sample app.