### PR TITLE
feat: Add ionic global error handler wrapper method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - build(internal): Switch to eslint
 - build(android): Bump Android SDK to v4.1.0 (#187)
+- feat: Add global error handler wrapper method for Ionic (#190)
 
 ## v0.17.0
 

--- a/src/js/Ionic/SentryIonicErrorHandler.ts
+++ b/src/js/Ionic/SentryIonicErrorHandler.ts
@@ -1,10 +1,18 @@
-class SentryIonicErrorHandler extends IonicErrorHandler {
-  handleError(error) {
-    super.handleError(error);
-    try {
-      captureException(error.originalError || error);
-    } catch (e) {
-      console.error(e);
+import { captureException } from '@sentry/core';
+
+/**
+ * Wrap the ionic error handler with this method so Sentry catches unhandled errors on ionic.
+ * See the documentation for more details.
+ */
+const withSentryIonicErrorHandler = <C extends new (...args: any[]) => any>(IonicErrorHandler: C): C => {
+  class SentryIonicErrorHandler extends IonicErrorHandler {
+    handleError(error: any) {
+      super.handleError(error);
+      captureException(error.originalError ?? error);
     }
   }
-}
+
+  return SentryIonicErrorHandler;
+};
+
+export { withSentryIonicErrorHandler };

--- a/src/js/__tests__/Ionic/SentryIonicErrorHandler.test.ts
+++ b/src/js/__tests__/Ionic/SentryIonicErrorHandler.test.ts
@@ -1,0 +1,40 @@
+import * as core from '@sentry/core';
+
+import { withSentryIonicErrorHandler } from '../../Ionic/SentryIonicErrorHandler';
+
+const captureException = jest.spyOn(core, 'captureException');
+
+describe('Global Ionic error handler', () => {
+  const originalHandleError = jest.fn();
+  class MockClass {
+    // Class method so it can be called via super
+    handleError(error: any) {
+      originalHandleError(error);
+    }
+  }
+
+  it('Calls captureException on error handler triggered', () => {
+    const SentryIonicErrorHandler = withSentryIonicErrorHandler(MockClass);
+    const errorHandler = new SentryIonicErrorHandler();
+
+    const error = new Error('Test Error');
+    errorHandler.handleError(error);
+
+    expect(originalHandleError).toHaveBeenLastCalledWith(error);
+    expect(captureException).toHaveBeenLastCalledWith(error);
+  });
+
+  it('Calls captureException with originalException if exists', () => {
+    const SentryIonicErrorHandler = withSentryIonicErrorHandler(MockClass);
+    const errorHandler = new SentryIonicErrorHandler();
+
+    const error = new Error('Test Error');
+    const originalError = new Error('Original Error');
+    Object.assign(error, { originalError });
+
+    errorHandler.handleError(error);
+
+    expect(originalHandleError).toHaveBeenLastCalledWith(error);
+    expect(captureException).toHaveBeenLastCalledWith(originalError);
+  });
+});

--- a/src/js/sentry-cordova.ts
+++ b/src/js/sentry-cordova.ts
@@ -36,3 +36,5 @@ export { SDK_NAME, SDK_VERSION } from './version';
 import * as Integrations from './integrations';
 export { Integrations };
 export { BrowserIntegrations };
+
+export { withSentryIonicErrorHandler } from './Ionic/SentryIonicErrorHandler';


### PR DESCRIPTION
Adds a method that wraps the ionic global error handler instead of needing the user to manually extend it. This also makes the dead code we used to have here be used.

### Usage:
```js
// app.module.ts
const SentryIonicErrorHandler = Sentry.withSentryIonicErrorHandler(IonicErrorHandler);

@NgModule({
    ...
    providers: [
        StatusBar,
        SplashScreen,
        // {provide: ErrorHandler, useClass: IonicErrorHandler} remove this, add next line (for Ionic 4 this line doen't exist by default)
        {provide: ErrorHandler, useClass: SentryIonicErrorHandler}
    ]
})
```

### Testing:
Tested on an Ionic sample app in chrome browser

### Next Steps:
We need to update the docs here: https://docs.sentry.io/platforms/javascript/guides/cordova/ionic/ to instead just have the user use this method.