### PR TITLE
build(js): Bump sentry-javascript dependencies to 6.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@sentry/minimal": "6.1.0",
     "@sentry/types": "6.1.0",
     "@sentry/utils": "6.1.0",
-    "@sentry/wizard": "^1.0.0"
+    "@sentry/wizard": "^1.1.4"
   },
   "devDependencies": {
     "@sentry-internal/eslint-config-sdk": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -24,16 +24,16 @@
   ],
   "description": "Official Sentry SDK for Cordova",
   "dependencies": {
-    "@sentry/browser": "~5.6.3",
-    "@sentry/core": "~5.6.2",
-    "@sentry/minimal": "~5.6.1",
-    "@sentry/types": "~5.6.1",
-    "@sentry/utils": "~5.6.1",
+    "@sentry/browser": "6.1.0",
+    "@sentry/core": "6.1.0",
+    "@sentry/minimal": "6.1.0",
+    "@sentry/types": "6.1.0",
+    "@sentry/utils": "6.1.0",
     "@sentry/wizard": "^1.0.0"
   },
   "devDependencies": {
-    "@sentry-internal/eslint-config-sdk": "5.21.0",
-    "@sentry-internal/typescript": "5.21.0",
+    "@sentry-internal/eslint-config-sdk": "6.1.0",
+    "@sentry-internal/typescript": "6.1.0",
     "@types/cordova": "0.0.34",
     "@types/jest": "^24.0.18",
     "@types/node": "^12.7.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -456,7 +456,7 @@
     "@sentry/types" "6.1.0"
     tslib "^1.9.3"
 
-"@sentry/wizard@^1.0.0":
+"@sentry/wizard@^1.1.4":
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/@sentry/wizard/-/wizard-1.1.4.tgz#df51af4271d11f729b938dde4864514b69e4aac9"
   integrity sha512-xVpL0lnQK2bbEwUKKjs3dKhy27va8HW75Q8r1vaR63iBCpB5LpP4Q4NN5G/VEWdYnH8rcazsOA207716E1cm4g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -363,13 +363,13 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@sentry-internal/eslint-config-sdk@5.21.0":
-  version "5.21.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-5.21.0.tgz#eae226fe47a6eddcdc326c733d08b9668940c43f"
-  integrity sha512-cu1JaU+eyzIrNGtPrwQEv5sfwPthUd/DSJZTGPPO4nDstUHk5uYUksvspLRhXP6Lrd4OolFWb90GgWZn5bSCZw==
+"@sentry-internal/eslint-config-sdk@6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-6.1.0.tgz#923da30ddf3115ad43b73535220294edb67b6071"
+  integrity sha512-m3tZDHjgm0NJ9PbL9UMKlKIhbY4qJa9PQ60FfT0eExrootb1SGj9rkwoHb67VXh/jOAOOsOF2C8/+H5Rf+C9tA==
   dependencies:
-    "@sentry-internal/eslint-plugin-sdk" "5.21.0"
-    "@sentry-internal/typescript" "5.21.0"
+    "@sentry-internal/eslint-plugin-sdk" "6.1.0"
+    "@sentry-internal/typescript" "6.1.0"
     "@typescript-eslint/eslint-plugin" "^3.9.0"
     "@typescript-eslint/parser" "^3.9.0"
     eslint-config-prettier "^6.11.0"
@@ -378,29 +378,29 @@
     eslint-plugin-jsdoc "^30.0.3"
     eslint-plugin-simple-import-sort "^5.0.3"
 
-"@sentry-internal/eslint-plugin-sdk@5.21.0":
-  version "5.21.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-5.21.0.tgz#ef28f8a6426f08d5cdb45e875695e426b68ca172"
-  integrity sha512-+ukO7eHyhDohiGGLP/9A7ndNfZBZAFTc70zqgd0hUYniQ/fMKkAuPTHXjIfYcq2asbHrqT2sa3OG1BG2FDtwhg==
+"@sentry-internal/eslint-plugin-sdk@6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-6.1.0.tgz#75340c0a6b87d2e2923861089ebbfd91eb427d3d"
+  integrity sha512-y4g0RPSJqnAP8DxG6a2glppjj39vUXeudnF9TY3JjGILWuhVbzWvsQv2nWZwyvVhdRgLhdwuCQQjlxgiIzJ8qg==
   dependencies:
     requireindex "~1.1.0"
 
-"@sentry-internal/typescript@5.21.0":
-  version "5.21.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-5.21.0.tgz#16f64bece69704f855762c6b401246ad3f7f28f4"
-  integrity sha512-bQwdppOtR1gCoSH4+wJ1XckYaZzUXIv4BqSbMIqwSJ5504YL9FCMBEXD6rA2jdKs9LPKX9MKpZMk3bOS+AMeqw==
+"@sentry-internal/typescript@6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-6.1.0.tgz#8bd3bb0a1800622c83d115a719a6c04686db6ee3"
+  integrity sha512-k+80w8vBgQrKI1gH7az9TVxQ6EjckcpNRawWFeW2ZQbpZK0BLki4U8Y9uFMgY5vURszK9F8LmN2MXSYdwsS1Uw==
   dependencies:
     tslint-config-prettier "^1.18.0"
     tslint-consistent-codestyle "^1.15.1"
 
-"@sentry/browser@~5.6.3":
-  version "5.6.3"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.6.3.tgz#5cc37b0443eba55ad13c13d34d6b95ff30dfbfe3"
-  integrity sha512-bP1LTbcKPOkkmfJOAM6c7WZ0Ov0ZEW6B9keVZ9wH9fw/lBPd9UyDMDCwJ+FAYKz9M9S5pxQeJ4Ebd7WUUrGVAQ==
+"@sentry/browser@6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-6.1.0.tgz#0e18a07b44bebed729bcf842af33203e388e2053"
+  integrity sha512-t3y2TLXDWgvfknyH8eKj/9mghJfSEqItFyp74zPu1Src6kOPjkd4Sa7o4+bdkNgA8dIIOrDAhRUbB2sq4sWMCA==
   dependencies:
-    "@sentry/core" "5.6.2"
-    "@sentry/types" "5.6.1"
-    "@sentry/utils" "5.6.1"
+    "@sentry/core" "6.1.0"
+    "@sentry/types" "6.1.0"
+    "@sentry/utils" "6.1.0"
     tslib "^1.9.3"
 
 "@sentry/cli@^1.52.4":
@@ -414,46 +414,46 @@
     progress "^2.0.3"
     proxy-from-env "^1.1.0"
 
-"@sentry/core@5.6.2", "@sentry/core@~5.6.2":
-  version "5.6.2"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.6.2.tgz#8c5477654a83ebe41a72e86a79215deb5025e418"
-  integrity sha512-grbjvNmyxP5WSPR6UobN2q+Nss7Hvz+BClBT8QTr7VTEG5q89TwNddn6Ej3bGkaUVbct/GpVlI3XflWYDsnU6Q==
+"@sentry/core@6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.1.0.tgz#7dd4584dcaf2188a78b94b766068342e6ee65229"
+  integrity sha512-57mXkp3NoyxRycXrL+Ec6bYS6UYJZp9tYX0lUp5Ry2M0FxDZ3Q4drkjr8MIQOhBaQXP2ukSX4QTVLGMPm60zMw==
   dependencies:
-    "@sentry/hub" "5.6.1"
-    "@sentry/minimal" "5.6.1"
-    "@sentry/types" "5.6.1"
-    "@sentry/utils" "5.6.1"
+    "@sentry/hub" "6.1.0"
+    "@sentry/minimal" "6.1.0"
+    "@sentry/types" "6.1.0"
+    "@sentry/utils" "6.1.0"
     tslib "^1.9.3"
 
-"@sentry/hub@5.6.1":
-  version "5.6.1"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.6.1.tgz#9f355c0abcc92327fbd10b9b939608aa4967bece"
-  integrity sha512-m+OhkIV5yTAL3R1+XfCwzUQka0UF/xG4py8sEfPXyYIcoOJ2ZTX+1kQJLy8QQJ4RzOBwZA+DzRKP0cgzPJ3+oQ==
+"@sentry/hub@6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.1.0.tgz#fb22734c91c9d68564737996bf28b7e032e3d8ee"
+  integrity sha512-JnBSCgNg3VHiMojUl5tCHU8iWPVuE+qqENIzG9A722oJms1kKWBvWl+yQzhWBNdgk5qeAY3F5UzKWJZkbJ6xow==
   dependencies:
-    "@sentry/types" "5.6.1"
-    "@sentry/utils" "5.6.1"
+    "@sentry/types" "6.1.0"
+    "@sentry/utils" "6.1.0"
     tslib "^1.9.3"
 
-"@sentry/minimal@5.6.1", "@sentry/minimal@~5.6.1":
-  version "5.6.1"
-  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.6.1.tgz#09d92b26de0b24555cd50c3c33ba4c3e566009a1"
-  integrity sha512-ercCKuBWHog6aS6SsJRuKhJwNdJ2oRQVWT2UAx1zqvsbHT9mSa8ZRjdPHYOtqY3DoXKk/pLUFW/fkmAnpdMqRw==
+"@sentry/minimal@6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.1.0.tgz#b3abf76d93b95477a3c1029db810818bdc56845f"
+  integrity sha512-g6sfNKenL7wnsr/tibp8nFiMv/XRH0s0Pt4p151npmNI+SmjuUz3GGYEXk8ChCyaKldYKilkNOFdVXJxUf5gZw==
   dependencies:
-    "@sentry/hub" "5.6.1"
-    "@sentry/types" "5.6.1"
+    "@sentry/hub" "6.1.0"
+    "@sentry/types" "6.1.0"
     tslib "^1.9.3"
 
-"@sentry/types@5.6.1", "@sentry/types@~5.6.1":
-  version "5.6.1"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.6.1.tgz#5915e1ee4b7a678da3ac260c356b1cb91139a299"
-  integrity sha512-Kub8TETefHpdhvtnDj3kKfhCj0u/xn3Zi2zIC7PB11NJHvvPXENx97tciz4roJGp7cLRCJsFqCg4tHXniqDSnQ==
+"@sentry/types@6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.1.0.tgz#5f9379229423ca1325acf6709e95687180f67132"
+  integrity sha512-kIaN52Fw5K+2mKRaHE2YluJ+F/qMGSUzZXIFDNdC6OUMXQ4TM8gZTrITXs8CLDm7cK8iCqFCtzKOjKK6KyOKAg==
 
-"@sentry/utils@5.6.1", "@sentry/utils@~5.6.1":
-  version "5.6.1"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.6.1.tgz#69d9e151e50415bc91f2428e3bcca8beb9bc2815"
-  integrity sha512-rfgha+UsHW816GqlSRPlniKqAZylOmQWML2JsujoUP03nPu80zdN43DK9Poy/d9OxBxv0gd5K2n+bFdM2kqLQQ==
+"@sentry/utils@6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.1.0.tgz#52e3d7050983e685d3a48f9d2efa1e6eb4ae3e6d"
+  integrity sha512-6JAplzUOS6bEwfX0PDRZBbYRvn9EN22kZfcL0qGHtM9L0QQ5ybjbbVwOpbXgRkiZx++dQbzLFtelxnDhsbFG+Q==
   dependencies:
-    "@sentry/types" "5.6.1"
+    "@sentry/types" "6.1.0"
     tslib "^1.9.3"
 
 "@sentry/wizard@^1.0.0":


### PR DESCRIPTION
Resolves #169,
Also bumps the wizard to 1.1.4