### PR TITLE
ref: Use platformId global instead of calling into native layer getPlatform

### DIFF
--- a/src/android/io/sentry/SentryCordova.java
+++ b/src/android/io/sentry/SentryCordova.java
@@ -37,9 +37,6 @@ public class SentryCordova extends CordovaPlugin {
 
           callbackContext.sendPluginResult(new PluginResult(Status.OK, true));
           break;
-        case "getPlatform":
-          callbackContext.sendPluginResult(new PluginResult(Status.OK, "android"));
-          break;
         default:
           callbackContext.sendPluginResult(new PluginResult(Status.ERROR, "not implemented"));
           break;

--- a/src/ios/SentryCordova.m
+++ b/src/ios/SentryCordova.m
@@ -11,16 +11,6 @@ NSString *const SentryCordovaSdkName = @"sentry-cordova";
   NSLog(@"Sentry Cordova Plugin initialized");
 }
 
-- (void)getPlatform:(CDVInvokedUrlCommand *)command {
-  CDVPluginResult *pluginResult =
-      [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
-                        messageAsString:@"ios"];
-  ;
-
-  [self.commandDelegate sendPluginResult:pluginResult
-                              callbackId:command.callbackId];
-}
-
 - (void)startWithOptions:(CDVInvokedUrlCommand *)command {
   NSDictionary *options = [command.arguments objectAtIndex:0];
 

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -1,5 +1,5 @@
-export enum CordovaDevicePlatform {
+export enum CordovaPlatformType {
   Ios = 'ios',
   Android = 'android',
-  Unknown = 'unknown',
+  Browser = 'browser',
 }

--- a/src/js/utils.ts
+++ b/src/js/utils.ts
@@ -1,4 +1,7 @@
 import { Severity } from '@sentry/types';
+import { getGlobalObject } from '@sentry/utils';
+
+import { CordovaPlatformType } from './types';
 
 /**
  * Serializes all values of root-level keys into strings.
@@ -30,4 +33,22 @@ export const processLevel = (level: Severity): Severity => {
   }
 
   return level;
+};
+
+/**
+ * Gets the platform
+ * @returns The current platform the SDK is running on, defaults to Browser if unknown.
+ */
+export const getPlatform = (): CordovaPlatformType => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const _window = getGlobalObject<any>();
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  let platform = _window?.cordova?.platformId;
+
+  if (!platform || !Object.values(CordovaPlatformType).includes(platform)) {
+    // Unsupported platform, default to browser
+    platform = CordovaPlatformType.Browser;
+  }
+
+  return platform;
 };


### PR DESCRIPTION
Uses the `window.cordova.platformId` global that's present on Cordova instead of calling into our native bridge and needing to await a promise to determine what platform it is being run on. This results in way cleaner code. Thus, this also removes the need to call into the native bridge (which we don't have a native module for, so it will throw an error that we catch) on browser and other platforms.

This `platformId` global has been there for [7 years or so, so it should be safe to use](https://github.com/apache/cordova-browser/blob/3b077ad590adc6f53a93b8af98efb20f8b1caeb7/cordova-lib/cordova.js#L180), but seems to not be documented anywhere.

This PR refactors how the native bridge checks whether the native SDK, native transport, and native scope sync is ready or not. We do this by storing which platform each feature is supported in the native wrapper: `SUPPORTS_NATIVE_TRANSPORT`, `SUPPORTS_NATIVE_SCOPE_SYNC`, `SUPPORTS_NATIVE_SDK`.



Tests on the native wrapper are also updated to reflect the changes here.