### PR TITLE
feat(android): Add Android native bridge, full scope sync, and cached events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - build(ios): Bump `sentry-cocoa` to 6.2.1 (#205)
+- feat(android): Add Android native bridge, full scope sync, and cached events (#202)
 
 ## v1.0.0-rc.0
 

--- a/src/android/io/sentry/SentryCordova.java
+++ b/src/android/io/sentry/SentryCordova.java
@@ -88,6 +88,20 @@ public class SentryCordova extends CordovaPlugin {
         callbackContext.sendPluginResult(new PluginResult(Status.OK, length));
 
         break;
+      case "setTag":
+        String tagKey = args.getString(0);
+        String tag = args.getString(1);
+
+        setTag(tagKey, tag, callbackContext);
+
+        break;
+      case "setExtra":
+        String extraKey = args.getString(0);
+        String extra = args.getString(1);
+
+        setExtra(extraKey, extra, callbackContext);
+
+        break;
       default:
         // callbackContext.sendPluginResult(new PluginResult(Status.ERROR, "not implemented"));
         break;
@@ -274,6 +288,18 @@ public class SentryCordova extends CordovaPlugin {
 
   private void clearBreadcrumbs(final CallbackContext callbackContext) {
     Sentry.configureScope(scope -> { scope.clearBreadcrumbs(); });
+    callbackContext.sendPluginResult(new PluginResult(Status.OK, true));
+  }
+
+  public void setExtra(String key, String extra, final CallbackContext callbackContext) {
+    Sentry.configureScope(scope -> { scope.setExtra(key, extra); });
+
+    callbackContext.sendPluginResult(new PluginResult(Status.OK, true));
+  }
+
+  public void setTag(String key, String value, final CallbackContext callbackContext) {
+    Sentry.configureScope(scope -> { scope.setTag(key, value); });
+
     callbackContext.sendPluginResult(new PluginResult(Status.OK, true));
   }
 

--- a/src/android/io/sentry/SentryCordova.java
+++ b/src/android/io/sentry/SentryCordova.java
@@ -1,7 +1,12 @@
 package io.sentry;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 import java.util.Date;
 import java.util.List;
+import java.util.UUID;
 import java.util.logging.Logger;
 
 import android.util.Log;
@@ -34,17 +39,46 @@ public class SentryCordova extends CordovaPlugin {
     Log.d(TAG, "Initializing Sentry");
   }
 
-  public boolean execute(String action, JSONArray args, final CallbackContext callbackContext) throws JSONException {
-    switch (action) {
-    case "startWithOptions":
-      JSONObject jsonOptions = args.getJSONObject(0);
+  public boolean execute(String action, JSONArray args, final CallbackContext callbackContext) {
+    // Special case for crash
+    if (action.equals("crash")) {
+      crash();
+    }
 
-      startWithOptions(jsonOptions, callbackContext);
+    try {
+      switch (action) {
+      case "startWithOptions":
+        JSONObject jsonOptions = args.getJSONObject(0);
 
-      break;
-    default:
-      callbackContext.sendPluginResult(new PluginResult(Status.ERROR, "not implemented"));
-      break;
+        startWithOptions(jsonOptions, callbackContext);
+
+        break;
+      case "captureEnvelope":
+        String envelope = args.getString(0);
+
+        captureEnvelope(envelope, callbackContext);
+
+        break;
+      case "getStringBytesLength":
+        String payload = args.getString(0);
+
+        int length = getStringBytesLength(payload);
+
+        callbackContext.sendPluginResult(new PluginResult(Status.OK, length));
+
+        break;
+      default:
+        callbackContext.sendPluginResult(new PluginResult(Status.ERROR, "not implemented"));
+        break;
+      }
+    } catch (Exception e) {
+      if (e instanceof JSONException) {
+        logger.info("Error parsing JSON from native bridge");
+      }
+
+      callbackContext.sendPluginResult(new PluginResult(Status.ERROR, false));
+
+      return false;
     }
 
     return true;
@@ -53,11 +87,60 @@ public class SentryCordova extends CordovaPlugin {
   private void startWithOptions(final JSONObject jsonOptions, final CallbackContext callbackContext) {
     SentryAndroid.init(this.cordova.getActivity().getApplicationContext(), options -> {
       try {
-        withJsonOptions(jsonOptions, options);
+        if (jsonOptions.has("dsn") && jsonOptions.getString("dsn") != null) {
+          String dsn = jsonOptions.getString("dsn");
+          logger.info(String.format("Starting with DSN: '%s'", dsn));
+          options.setDsn(dsn);
+        } else {
+          // SentryAndroid needs an empty string fallback for the dsn.
+          options.setDsn("");
+        }
+        if (jsonOptions.has("debug") && jsonOptions.getBoolean("debug")) {
+          options.setDebug(true);
+        }
+        if (jsonOptions.has("maxBreadcrumbs")) {
+          options.setMaxBreadcrumbs(jsonOptions.getInt("maxBreadcrumbs"));
+        }
+        if (jsonOptions.has("environment") && jsonOptions.getString("environment") != null) {
+          options.setEnvironment(jsonOptions.getString("environment"));
+        }
+        if (jsonOptions.has("release") && jsonOptions.getString("release") != null) {
+          options.setRelease(jsonOptions.getString("release"));
+        }
+        if (jsonOptions.has("dist") && jsonOptions.getString("dist") != null) {
+          options.setDist(jsonOptions.getString("dist"));
+        }
+        if (jsonOptions.has("enableAutoSessionTracking")) {
+          options.setEnableSessionTracking(jsonOptions.getBoolean("enableAutoSessionTracking"));
+        }
+        if (jsonOptions.has("sessionTrackingIntervalMillis")) {
+          options.setSessionTrackingIntervalMillis(jsonOptions.getInt("sessionTrackingIntervalMillis"));
+        }
+        if (jsonOptions.has("enableNdkScopeSync")) {
+          options.setEnableScopeSync(jsonOptions.getBoolean("enableNdkScopeSync"));
+        }
+        if (jsonOptions.has("attachStacktrace")) {
+          options.setAttachStacktrace(jsonOptions.getBoolean("attachStacktrace"));
+        }
+        if (jsonOptions.has("attachThreads")) {
+          // JS use top level stacktraces and android attaches Threads which
+          // hides them so by default we hide.
+          options.setAttachThreads(jsonOptions.getBoolean("attachThreads"));
+        }
+
+        if (jsonOptions.has("enableNativeCrashHandling") && !jsonOptions.getBoolean("enableNativeCrashHandling")) {
+          final List<Integration> integrations = options.getIntegrations();
+          for (final Integration integration : integrations) {
+            if (integration instanceof UncaughtExceptionHandlerIntegration || integration instanceof AnrIntegration || integration instanceof NdkIntegration) {
+              integrations.remove(integration);
+            }
+          }
+        }
+
         logger.info(String.format("Native Integrations '%s'", options.getIntegrations().toString()));
         sentryOptions = options;
       } catch (JSONException e) {
-        logger.error("Error parsing options JSON sent over native bridge.");
+        logger.info("Error parsing options JSON sent over native bridge.");
         callbackContext.sendPluginResult(new PluginResult(Status.ERROR, false));
       }
     });
@@ -65,55 +148,21 @@ public class SentryCordova extends CordovaPlugin {
     callbackContext.sendPluginResult(new PluginResult(Status.OK, true));
   }
 
-  private void withJsonOptions(final JSONObject jsonOptions, SentryOptions options) throws JSONException {
-    if (jsonOptions.has("dsn") && jsonOptions.getString("dsn") != null) {
-      String dsn = jsonOptions.getString("dsn");
-      logger.info(String.format("Starting with DSN: '%s'", dsn));
-      options.setDsn(dsn);
-    } else {
-      // SentryAndroid needs an empty string fallback for the dsn.
-      options.setDsn("");
-    }
-    if (jsonOptions.has("debug") && jsonOptions.getBoolean("debug")) {
-      options.setDebug(true);
-    }
-    if (jsonOptions.has("maxBreadcrumbs")) {
-      options.setMaxBreadcrumbs(jsonOptions.getInt("maxBreadcrumbs"));
-    }
-    if (jsonOptions.has("environment") && jsonOptions.getString("environment") != null) {
-      options.setEnvironment(jsonOptions.getString("environment"));
-    }
-    if (jsonOptions.has("release") && jsonOptions.getString("release") != null) {
-      options.setRelease(jsonOptions.getString("release"));
-    }
-    if (jsonOptions.has("dist") && jsonOptions.getString("dist") != null) {
-      options.setDist(jsonOptions.getString("dist"));
-    }
-    if (jsonOptions.has("enableAutoSessionTracking")) {
-      options.setEnableSessionTracking(jsonOptions.getBoolean("enableAutoSessionTracking"));
-    }
-    if (jsonOptions.has("sessionTrackingIntervalMillis")) {
-      options.setSessionTrackingIntervalMillis(jsonOptions.getInt("sessionTrackingIntervalMillis"));
-    }
-    if (jsonOptions.has("enableNdkScopeSync")) {
-      options.setEnableScopeSync(jsonOptions.getBoolean("enableNdkScopeSync"));
-    }
-    if (jsonOptions.has("attachStacktrace")) {
-      options.setAttachStacktrace(jsonOptions.getBoolean("attachStacktrace"));
-    }
-    if (jsonOptions.has("attachThreads")) {
-      // JS use top level stacktraces and android attaches Threads which
-      // hides them so by default we hide.
-      options.setAttachThreads(jsonOptions.getBoolean("attachThreads"));
+  private void captureEnvelope(String envelope, final CallbackContext callbackContext) {
+    try {
+      File installation = new File(sentryOptions.getOutboxPath(), UUID.randomUUID().toString());
+      try (FileOutputStream out = new FileOutputStream(installation)) {
+        out.write(envelope.getBytes(Charset.forName("UTF-8")));
+      }
+    } catch (Exception e) {
+      logger.info("Error reading envelope");
+      callbackContext.sendPluginResult(new PluginResult(Status.ERROR, false));
     }
 
-    if (jsonOptions.has("enableNativeCrashHandling") && !jsonOptions.getBoolean("enableNativeCrashHandling")) {
-      final List<Integration> integrations = options.getIntegrations();
-      for (final Integration integration : integrations) {
-        if (integration instanceof UncaughtExceptionHandlerIntegration || integration instanceof AnrIntegration || integration instanceof NdkIntegration) {
-          integrations.remove(integration);
-        }
-      }
-    }
+    callbackContext.sendPluginResult(new PluginResult(Status.OK, true));
   }
+
+  private int getStringBytesLength(String payload) throws UnsupportedEncodingException { return payload.getBytes("UTF-8").length; }
+
+  private void crash() { throw new RuntimeException("TEST - Sentry Client Crash (only works in release mode)"); }
 }

--- a/src/android/io/sentry/SentryCordova.java
+++ b/src/android/io/sentry/SentryCordova.java
@@ -46,7 +46,7 @@ public class SentryCordova extends CordovaPlugin {
   }
 
   public boolean execute(String action, JSONArray args, final CallbackContext callbackContext) {
-    // Special case for crash
+    // Special case for crash outside the try/catch block
     if (action.equals("crash")) {
       crash();
       return true;

--- a/src/android/io/sentry/SentryCordova.java
+++ b/src/android/io/sentry/SentryCordova.java
@@ -98,7 +98,10 @@ public class SentryCordova extends CordovaPlugin {
         break;
       case "setContext":
         String contextKey = args.getString(0);
-        JSONObject contextObject = args.getJSONObject(1);
+        JSONObject contextObject = null;
+        if (!args.isNull(1)) {
+          contextObject = args.getJSONObject(1);
+        }
 
         setContext(contextKey, contextObject, callbackContext);
 

--- a/src/android/io/sentry/SentryCordova.java
+++ b/src/android/io/sentry/SentryCordova.java
@@ -10,6 +10,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import android.util.Log;
@@ -126,12 +127,13 @@ public class SentryCordova extends CordovaPlugin {
       }
 
     } catch (JSONException e) {
-      logger.info("Error parsing JSON from native bridge");
+      logger.log(Level.SEVERE, "Error parsing JSON from native bridge");
 
       callbackContext.sendPluginResult(new PluginResult(Status.ERROR, false));
 
       return false;
     } catch (Exception e) {
+      logger.log(Level.SEVERE, "Error occurred on native bridge: ", e);
 
       callbackContext.sendPluginResult(new PluginResult(Status.ERROR, false));
 

--- a/src/android/io/sentry/SentryCordova.java
+++ b/src/android/io/sentry/SentryCordova.java
@@ -68,6 +68,9 @@ public class SentryCordova extends CordovaPlugin {
         addBreadcrumb(jsonBreadcrumb, callbackContext);
 
         break;
+      case "clearBreadcrumbs":
+        clearBreadcrumbs(callbackContext);
+        break;
       case "getStringBytesLength":
         String payload = args.getString(0);
 
@@ -209,6 +212,11 @@ public class SentryCordova extends CordovaPlugin {
         logger.info("Error deserializing breadcrumb");
       }
     });
+  }
+
+  private void clearBreadcrumbs(final CallbackContext callbackContext) {
+    Sentry.configureScope(scope -> { scope.clearBreadcrumbs(); });
+    callbackContext.sendPluginResult(new PluginResult(Status.OK, true));
   }
 
   private int getStringBytesLength(String payload) throws UnsupportedEncodingException { return payload.getBytes("UTF-8").length; }

--- a/src/android/io/sentry/SentryCordova.java
+++ b/src/android/io/sentry/SentryCordova.java
@@ -43,6 +43,7 @@ public class SentryCordova extends CordovaPlugin {
     // Special case for crash
     if (action.equals("crash")) {
       crash();
+      return true;
     }
 
     try {

--- a/src/android/io/sentry/SentryCordova.java
+++ b/src/android/io/sentry/SentryCordova.java
@@ -198,7 +198,7 @@ public class SentryCordova extends CordovaPlugin {
 
           sentryOptions = options;
         } catch (JSONException e) {
-          logger.info("Error parsing options JSON sent over native bridge.");
+          logger.severe("Error parsing options JSON sent over native bridge.");
           callbackContext.sendPluginResult(new PluginResult(Status.ERROR, false));
         }
       });
@@ -277,7 +277,7 @@ public class SentryCordova extends CordovaPlugin {
           scope.setUser(userInstance);
         }
       } catch (JSONException e) {
-        logger.info("Error deserializing user");
+        logger.warning("Error deserializing user");
       }
     });
 
@@ -319,7 +319,7 @@ public class SentryCordova extends CordovaPlugin {
         scope.addBreadcrumb(breadcrumb);
         logger.info("Send breadcrumb successful");
       } catch (JSONException e) {
-        logger.info("Error deserializing breadcrumb");
+        logger.warning("Error deserializing breadcrumb");
       }
     });
   }

--- a/src/android/io/sentry/SentryCordova.java
+++ b/src/android/io/sentry/SentryCordova.java
@@ -66,8 +66,15 @@ public class SentryCordova extends CordovaPlugin {
 
         break;
       case "setUser":
-        JSONObject jsonUser = args.getJSONObject(0);
-        JSONObject otherUserKeys = args.getJSONObject(1);
+        JSONObject jsonUser = null;
+        JSONObject otherUserKeys = null;
+
+        if (!args.isNull(0)) {
+          jsonUser = args.getJSONObject(0);
+        }
+        if (!args.isNull(1)) {
+          otherUserKeys = args.getJSONObject(1);
+        }
 
         setUser(jsonUser, otherUserKeys, callbackContext);
 

--- a/src/android/io/sentry/SentryCordova.java
+++ b/src/android/io/sentry/SentryCordova.java
@@ -1,23 +1,33 @@
 package io.sentry;
 
+import java.util.Date;
+import java.util.List;
+import java.util.logging.Logger;
+
+import android.util.Log;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaInterface;
 import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.CordovaWebView;
 import org.apache.cordova.PluginResult;
 import org.apache.cordova.PluginResult.Status;
-import org.json.JSONObject;
-import org.json.JSONArray;
-import org.json.JSONException;
 
-import android.util.Log;
-
-import java.util.Date;
-
+import io.sentry.UncaughtExceptionHandlerIntegration;
+import io.sentry.android.core.AnrIntegration;
+import io.sentry.android.core.NdkIntegration;
 import io.sentry.android.core.SentryAndroid;
 
 public class SentryCordova extends CordovaPlugin {
   private static final String TAG = "Sentry";
+
+  final static Logger logger = Logger.getLogger("sentry-cordova");
+
+  private SentryOptions sentryOptions;
 
   public void initialize(CordovaInterface cordova, CordovaWebView webView) {
     super.initialize(cordova, webView);
@@ -25,23 +35,85 @@ public class SentryCordova extends CordovaPlugin {
   }
 
   public boolean execute(String action, JSONArray args, final CallbackContext callbackContext) throws JSONException {
-      switch(action) {
-        case "startWithOptions":
-          JSONObject jsonOptions = args.getJSONObject(0);
-          
-          String dsn = jsonOptions.getString("dsn");
+    switch (action) {
+    case "startWithOptions":
+      JSONObject jsonOptions = args.getJSONObject(0);
 
-          SentryAndroid.init(this.cordova.getActivity().getApplicationContext(), options -> {
-            options.setDsn(dsn);
-          });
+      startWithOptions(jsonOptions, callbackContext);
 
-          callbackContext.sendPluginResult(new PluginResult(Status.OK, true));
-          break;
-        default:
-          callbackContext.sendPluginResult(new PluginResult(Status.ERROR, "not implemented"));
-          break;
+      break;
+    default:
+      callbackContext.sendPluginResult(new PluginResult(Status.ERROR, "not implemented"));
+      break;
+    }
+
+    return true;
+  }
+
+  private void startWithOptions(final JSONObject jsonOptions, final CallbackContext callbackContext) {
+    SentryAndroid.init(this.cordova.getActivity().getApplicationContext(), options -> {
+      try {
+        withJsonOptions(jsonOptions, options);
+        logger.info(String.format("Native Integrations '%s'", options.getIntegrations().toString()));
+        sentryOptions = options;
+      } catch (JSONException e) {
+        logger.error("Error parsing options JSON sent over native bridge.");
+        callbackContext.sendPluginResult(new PluginResult(Status.ERROR, false));
       }
+    });
 
-      return true;
+    callbackContext.sendPluginResult(new PluginResult(Status.OK, true));
+  }
+
+  private void withJsonOptions(final JSONObject jsonOptions, SentryOptions options) throws JSONException {
+    if (jsonOptions.has("dsn") && jsonOptions.getString("dsn") != null) {
+      String dsn = jsonOptions.getString("dsn");
+      logger.info(String.format("Starting with DSN: '%s'", dsn));
+      options.setDsn(dsn);
+    } else {
+      // SentryAndroid needs an empty string fallback for the dsn.
+      options.setDsn("");
+    }
+    if (jsonOptions.has("debug") && jsonOptions.getBoolean("debug")) {
+      options.setDebug(true);
+    }
+    if (jsonOptions.has("maxBreadcrumbs")) {
+      options.setMaxBreadcrumbs(jsonOptions.getInt("maxBreadcrumbs"));
+    }
+    if (jsonOptions.has("environment") && jsonOptions.getString("environment") != null) {
+      options.setEnvironment(jsonOptions.getString("environment"));
+    }
+    if (jsonOptions.has("release") && jsonOptions.getString("release") != null) {
+      options.setRelease(jsonOptions.getString("release"));
+    }
+    if (jsonOptions.has("dist") && jsonOptions.getString("dist") != null) {
+      options.setDist(jsonOptions.getString("dist"));
+    }
+    if (jsonOptions.has("enableAutoSessionTracking")) {
+      options.setEnableSessionTracking(jsonOptions.getBoolean("enableAutoSessionTracking"));
+    }
+    if (jsonOptions.has("sessionTrackingIntervalMillis")) {
+      options.setSessionTrackingIntervalMillis(jsonOptions.getInt("sessionTrackingIntervalMillis"));
+    }
+    if (jsonOptions.has("enableNdkScopeSync")) {
+      options.setEnableScopeSync(jsonOptions.getBoolean("enableNdkScopeSync"));
+    }
+    if (jsonOptions.has("attachStacktrace")) {
+      options.setAttachStacktrace(jsonOptions.getBoolean("attachStacktrace"));
+    }
+    if (jsonOptions.has("attachThreads")) {
+      // JS use top level stacktraces and android attaches Threads which
+      // hides them so by default we hide.
+      options.setAttachThreads(jsonOptions.getBoolean("attachThreads"));
+    }
+
+    if (jsonOptions.has("enableNativeCrashHandling") && !jsonOptions.getBoolean("enableNativeCrashHandling")) {
+      final List<Integration> integrations = options.getIntegrations();
+      for (final Integration integration : integrations) {
+        if (integration instanceof UncaughtExceptionHandlerIntegration || integration instanceof AnrIntegration || integration instanceof NdkIntegration) {
+          integrations.remove(integration);
+        }
+      }
+    }
   }
 }

--- a/src/android/io/sentry/SentryCordova.java
+++ b/src/android/io/sentry/SentryCordova.java
@@ -144,16 +144,18 @@ public class SentryCordova extends CordovaPlugin {
   }
 
   private void startWithOptions(final JSONObject jsonOptions, final CallbackContext callbackContext) {
+    String dsn = jsonOptions.optString("dsn", null);
+
+    if (dsn == null) {
+      logger.log(Level.SEVERE, "No DSN passed through native bridge, native Android SDK will not start.");
+
+      callbackContext.sendPluginResult(new PluginResult(Status.ERROR, "Missing dsn"));
+    } else {
     SentryAndroid.init(this.cordova.getActivity().getApplicationContext(), options -> {
       try {
-        if (jsonOptions.has("dsn") && jsonOptions.getString("dsn") != null) {
-          String dsn = jsonOptions.getString("dsn");
           logger.info(String.format("Starting with DSN: '%s'", dsn));
           options.setDsn(dsn);
-        } else {
-          // SentryAndroid needs an empty string fallback for the dsn.
-          options.setDsn("");
-        }
+
         if (jsonOptions.has("debug") && jsonOptions.getBoolean("debug")) {
           options.setDebug(true);
         }
@@ -205,6 +207,7 @@ public class SentryCordova extends CordovaPlugin {
     });
 
     callbackContext.sendPluginResult(new PluginResult(Status.OK, true));
+  }
   }
 
   private void captureEnvelope(String envelope, final CallbackContext callbackContext) {

--- a/src/js/backend.ts
+++ b/src/js/backend.ts
@@ -16,7 +16,24 @@ export interface CordovaOptions extends BrowserOptions {
    * Enables crash reporting for native crashes.
    * Defaults to `true`.
    */
-  enableNative?: boolean;
+  enableNative: boolean;
+
+  /**
+   * Should sessions be tracked to Sentry Health or not.
+   * Defaults to `true`.
+   *
+   * NOTE: Currently only supported on Android and iOS. Browser not yet supported.
+   */
+  enableAutoSessionTracking: boolean;
+
+  /** The interval to end a session if the App goes to the background. */
+  sessionTrackingIntervalMillis?: number;
+
+  /** Enable scope sync from Java to NDK on Android */
+  enableNdkScopeSync: boolean;
+
+  /** When enabled, all the threads are automatically attached to all logged events on Android */
+  attachThreads: boolean;
 }
 
 /** The Sentry Cordova SDK Backend. */

--- a/src/js/backend.ts
+++ b/src/js/backend.ts
@@ -43,7 +43,7 @@ export class CordovaBackend extends BaseBackend<BrowserOptions> {
   private readonly _deviceReadyCallback?: () => void;
 
   /** Creates a new cordova backend instance. */
-  public constructor(protected readonly _options: CordovaOptions = {}) {
+  public constructor(protected readonly _options: CordovaOptions) {
     super(_options);
     this._browserBackend = new BrowserBackend(_options);
 

--- a/src/js/backend.ts
+++ b/src/js/backend.ts
@@ -16,7 +16,7 @@ export interface CordovaOptions extends BrowserOptions {
    * Enables crash reporting for native crashes.
    * Defaults to `true`.
    */
-  enableNative: boolean;
+  enableNative?: boolean;
 
   /**
    * Should sessions be tracked to Sentry Health or not.
@@ -24,16 +24,16 @@ export interface CordovaOptions extends BrowserOptions {
    *
    * NOTE: Currently only supported on Android and iOS. Browser not yet supported.
    */
-  enableAutoSessionTracking: boolean;
+  enableAutoSessionTracking?: boolean;
 
   /** The interval to end a session if the App goes to the background. */
   sessionTrackingIntervalMillis?: number;
 
   /** Enable scope sync from Java to NDK on Android */
-  enableNdkScopeSync: boolean;
+  enableNdkScopeSync?: boolean;
 
   /** When enabled, all the threads are automatically attached to all logged events on Android */
-  attachThreads: boolean;
+  attachThreads?: boolean;
 }
 
 /** The Sentry Cordova SDK Backend. */

--- a/src/js/sdk.ts
+++ b/src/js/sdk.ts
@@ -1,4 +1,4 @@
-import { defaultIntegrations } from '@sentry/browser';
+import { defaultIntegrations as defaultBrowserIntegrations } from '@sentry/browser';
 import { Hub, initAndBind, makeMain } from '@sentry/core';
 import { configureScope } from '@sentry/minimal';
 import { Scope } from '@sentry/types';
@@ -9,13 +9,22 @@ import { Cordova, Release } from './integrations';
 import { CordovaScope } from './scope';
 import { NATIVE } from './wrapper';
 
+const DEFAULT_INTEGRATIONS = [...defaultBrowserIntegrations, new Cordova(), new Release()];
+
+const DEFAULT_OPTIONS: CordovaOptions = {
+  enableNative: true,
+  defaultIntegrations: DEFAULT_INTEGRATIONS,
+  enableAutoSessionTracking: true,
+  enableNdkScopeSync: false,
+  attachThreads: false,
+};
+
 /**
  * Inits the SDK
  */
-export function init(_options: CordovaOptions): void {
+export function init(_options: Partial<CordovaOptions>): void {
   const options = {
-    enableNative: true,
-    defaultIntegrations: [...defaultIntegrations, new Cordova(), new Release()],
+    ...DEFAULT_OPTIONS,
     ..._options,
   };
 

--- a/src/js/sdk.ts
+++ b/src/js/sdk.ts
@@ -7,6 +7,7 @@ import { CordovaOptions } from './backend';
 import { CordovaClient } from './client';
 import { Cordova, Release } from './integrations';
 import { CordovaScope } from './scope';
+import { NATIVE } from './wrapper';
 
 /**
  * Inits the SDK
@@ -41,4 +42,14 @@ export function setDist(dist: string): void {
   configureScope((scope: Scope) => {
     scope.setExtra('__sentry_dist', dist);
   });
+}
+
+/**
+ * If native client is available it will trigger a native crash.
+ * Use this only for testing purposes.
+ */
+export function nativeCrash(): void {
+  if (NATIVE.isNativeClientAvailable()) {
+    NATIVE.crash();
+  }
 }

--- a/src/js/sentry-cordova.ts
+++ b/src/js/sentry-cordova.ts
@@ -36,7 +36,7 @@ export {
 import { Integrations as BrowserIntegrations } from '@sentry/browser';
 export { CordovaBackend, CordovaOptions } from './backend';
 export { CordovaClient } from './client';
-export { init, setDist, setRelease } from './sdk';
+export { init, setDist, setRelease, nativeCrash } from './sdk';
 export { SDK_NAME, SDK_VERSION } from './version';
 
 import * as Integrations from './integrations';

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -12,7 +12,7 @@ import { getPlatform, processLevel, serializeObject } from './utils';
 export const NATIVE = {
   PLUGIN_NAME: 'Sentry',
   SUPPORTS_NATIVE_TRANSPORT: [CordovaPlatformType.Ios, CordovaPlatformType.Android],
-  SUPPORTS_NATIVE_SCOPE_SYNC: [CordovaPlatformType.Ios],
+  SUPPORTS_NATIVE_SCOPE_SYNC: [CordovaPlatformType.Ios, CordovaPlatformType.Android],
   SUPPORTS_NATIVE_SDK: [CordovaPlatformType.Android, CordovaPlatformType.Ios],
   /**
    * Starts native with the provided options.

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -18,8 +18,13 @@ export const NATIVE = {
    * Starts native with the provided options.
    * @param options CordovaOptions
    */
-  async startWithOptions(options: CordovaOptions): Promise<boolean> {
+  async startWithOptions(_options: CordovaOptions): Promise<boolean> {
     if (this.SUPPORTS_NATIVE_SDK.includes(getPlatform())) {
+      const options = {
+        enableNative: true,
+        ..._options,
+      };
+
       this.enableNative = options.enableNative;
 
       if (!options.enableNative) {

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -18,13 +18,8 @@ export const NATIVE = {
    * Starts native with the provided options.
    * @param options CordovaOptions
    */
-  async startWithOptions(_options: CordovaOptions): Promise<boolean> {
+  async startWithOptions(options: CordovaOptions): Promise<boolean> {
     if (this.SUPPORTS_NATIVE_SDK.includes(getPlatform())) {
-      const options = {
-        enableNative: true,
-        ..._options,
-      };
-
       this.enableNative = options.enableNative;
 
       if (!options.enableNative) {


### PR DESCRIPTION
Complete Android native bridge module to be not just on par with React Native, with `setContext` support as well which RN does not have.

Features:
- Pass options to Android SDK
- Native Crash on Android for testing (Does not actually crash the app, but throws an error and we catch it)
- Add and clear Breadcrumbs 
- setUser, along with passing `null` to clear user
- setTag and setExtra
- setContext, pass `null` to clear a context.
- Write envelope to disk to support offline caching (Resolves #188)

Extra:
- As we add a `nativeCrash` method on the native wrapper on the JS side, this also enables native crash functionality on iOS. (Resolves #197)

Tested on a local Cordova sample app. (Should integrate this sample app into this repo at a later date)