### PR TITLE
feat: Set event.origin and event.environment tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - build(ios): Bump `sentry-cocoa` to 6.2.1 (#205)
 - feat(android): Add Android native bridge, full scope sync, and cached events (#202)
+- feat: Set `event.origin` and `event.environment` tags (#204)
 
 ## v1.0.0-rc.0
 

--- a/src/android/io/sentry/SentryCordova.java
+++ b/src/android/io/sentry/SentryCordova.java
@@ -31,6 +31,7 @@ import io.sentry.UncaughtExceptionHandlerIntegration;
 import io.sentry.android.core.AnrIntegration;
 import io.sentry.android.core.NdkIntegration;
 import io.sentry.android.core.SentryAndroid;
+import io.sentry.protocol.SdkVersion;
 import io.sentry.protocol.User;
 
 public class SentryCordova extends CordovaPlugin {
@@ -195,6 +196,12 @@ public class SentryCordova extends CordovaPlugin {
             options.setAnrEnabled(false);
             options.setEnableNdk(false);
           }
+
+          options.setBeforeSend((event, hint) -> {
+            setEventOriginTag(event);
+
+            return event;
+          });
 
           sentryOptions = options;
         } catch (JSONException e) {
@@ -378,6 +385,31 @@ public class SentryCordova extends CordovaPlugin {
     default:
       return SentryLevel.ERROR;
     }
+  }
+
+  private final String androidSdk = "sentry.java.android";
+  private final String nativeSdk = "sentry.native";
+
+  private void setEventOriginTag(SentryEvent event) {
+    SdkVersion sdk = event.getSdk();
+    if (sdk != null) {
+      switch (sdk.getName()) {
+      // If the event is from cordova js, it gets set there and we do not handle it here.
+      case nativeSdk:
+        setEventEnvironmentTag(event, "android", "native");
+        break;
+      case androidSdk:
+        setEventEnvironmentTag(event, "android", "java");
+        break;
+      default:
+        break;
+      }
+    }
+  }
+
+  private void setEventEnvironmentTag(SentryEvent event, String origin, String environment) {
+    event.setTag("event.origin", origin);
+    event.setTag("event.environment", environment);
   }
 
   private void crash() { Sentry.captureException(new RuntimeException("TEST - Sentry Silent Client Crash")); }

--- a/src/android/io/sentry/SentryCordova.java
+++ b/src/android/io/sentry/SentryCordova.java
@@ -387,18 +387,15 @@ public class SentryCordova extends CordovaPlugin {
     }
   }
 
-  private final String androidSdk = "sentry.java.android";
-  private final String nativeSdk = "sentry.native";
-
   private void setEventOriginTag(SentryEvent event) {
     SdkVersion sdk = event.getSdk();
     if (sdk != null) {
       switch (sdk.getName()) {
       // If the event is from cordova js, it gets set there and we do not handle it here.
-      case nativeSdk:
+      case "sentry.native":
         setEventEnvironmentTag(event, "android", "native");
         break;
-      case androidSdk:
+      case "sentry.java.android":
         setEventEnvironmentTag(event, "android", "java");
         break;
       default:

--- a/src/ios/SentryCordova.m
+++ b/src/ios/SentryCordova.m
@@ -52,7 +52,9 @@ NSString *const cocoaSdk = @"sentry.cocoa";
 
 - (void)setEventEnvironmentTag:(SentryEvent *)event origin:(NSString *)origin environment:(NSString *)environment {
   NSMutableDictionary *newTags = [NSMutableDictionary new];
-  [newTags addEntriesFromDictionary:event.tags];
+  if (nil != event.tags) {
+    [newTags addEntriesFromDictionary:event.tags];
+  }
   [newTags setValue:origin forKey:@"event.origin"];
   [newTags setValue:environment forKey:@"event.environment"];
   event.tags = newTags;

--- a/src/ios/SentryCordova.m
+++ b/src/ios/SentryCordova.m
@@ -2,8 +2,6 @@
 #import <Cordova/CDVAvailability.h>
 @import Sentry;
 
-NSString *const cocoaSdk = @"sentry.cocoa";
-
 @implementation SentryCordova
 
 - (void)pluginInitialize {
@@ -44,7 +42,7 @@ NSString *const cocoaSdk = @"sentry.cocoa";
     NSString *sdkName = event.sdk[@"name"];
 
     // If the event is from cordova js, it gets set there and we do not handle it here.
-    if ([sdkName isEqualToString:cocoaSdk]) {
+    if ([sdkName isEqualToString:@"sentry.cocoa"]) {
       [self setEventEnvironmentTag:event origin:@"ios" environment:@"native"];
     }
   }

--- a/src/js/client.ts
+++ b/src/js/client.ts
@@ -37,6 +37,12 @@ export class CordovaClient extends BaseClient<CordovaBackend, CordovaOptions> {
       version: SDK_VERSION,
     };
 
+    if (!event.tags) {
+      event.tags = {};
+    }
+    event.tags['event.origin'] = 'cordova';
+    event.tags['event.environment'] = 'javascript';
+
     return super._prepareEvent(event, scope, hint);
   }
 }


### PR DESCRIPTION
Sets `event.origin` and `event.environment` tags to be in line with `sentry-dart`.

They are set on the JS layer if the event comes from JS due to the events being sent through `captureEnvelope` on cocoa, which is not passed through `beforeSend`. ([Is this an issue on Flutter?](https://github.com/getsentry/sentry-dart/blob/ae21d7e44203fb544f97bd7b21b9bd2b4b779454/flutter/ios/Classes/SwiftSentryFlutterPlugin.swift#L205-L206))