### PR TITLE
build(ios): Bump sentry-cocoa to 6.2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ package-lock.json
 
 # Eslint
 .eslintcache
+
+# Generated Lockfiles
+Cartfile.resolved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- build(ios): Bump `sentry-cocoa` to 6.2.1
+
 ## v1.0.0-rc.0
 
 - build(internal): Switch to eslint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- build(ios): Bump `sentry-cocoa` to 6.2.1
+- build(ios): Bump `sentry-cocoa` to 6.2.1 (#205)
 
 ## v1.0.0-rc.0
 

--- a/src/ios/Cartfile
+++ b/src/ios/Cartfile
@@ -1,1 +1,1 @@
-github "getsentry/sentry-cocoa" "6.1.4"
+github "getsentry/sentry-cocoa" "6.2.1"

--- a/src/ios/Cartfile.resolved
+++ b/src/ios/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "getsentry/sentry-cocoa" "6.1.4"
+github "getsentry/sentry-cocoa" "6.2.1"

--- a/src/ios/Cartfile.resolved
+++ b/src/ios/Cartfile.resolved
@@ -1,1 +1,0 @@
-github "getsentry/sentry-cocoa" "6.2.1"


### PR DESCRIPTION
Resolves #201 