### PR TITLE
fix: Support clearing user with null on iOS native bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - build(ios): Bump `sentry-cocoa` to 6.2.1 (#205)
 - feat(android): Add Android native bridge, full scope sync, and cached events (#202)
 - feat: Set `event.origin` and `event.environment` tags (#204)
+- fix: Support clearing user with null on iOS native bridge (#207)
 
 ## v1.0.0-rc.0
 

--- a/src/ios/SentryCordova.m
+++ b/src/ios/SentryCordova.m
@@ -182,19 +182,23 @@
   NSDictionary *user = [command.arguments objectAtIndex:0];
   NSDictionary *otherUserKeys = [command.arguments objectAtIndex:1];
 
+  bool userIsNull = (nil == user || [user isEqual:[NSNull null]]);
+  bool otherUserKeysIsNull =
+      (nil == otherUserKeys || [otherUserKeys isEqual:[NSNull null]]);
+
   [SentrySDK configureScope:^(SentryScope *_Nonnull scope) {
-    if (nil == user && nil == otherUserKeys) {
+    if (userIsNull && otherUserKeysIsNull) {
       [scope setUser:nil];
     } else {
       SentryUser *userInstance = [[SentryUser alloc] init];
 
-      if (nil != user) {
+      if (!userIsNull) {
         [userInstance setUserId:user[@"id"]];
         [userInstance setEmail:user[@"email"]];
         [userInstance setUsername:user[@"username"]];
       }
 
-      if (nil != otherUserKeys) {
+      if (!otherUserKeysIsNull) {
         [userInstance setData:otherUserKeys];
       }
 


### PR DESCRIPTION
Cordova passes the values as `NSNull` and not `nil` like on React Native.

Fixes #203 

## Testing:

Tested on Cordova sample app that after setting the user on the scope, calling `setUser` on the JS layer with `null` clears the user on iOS in a native crash.