### PR TITLE
ref: Get payload length in captureEnvelope on Android

### DIFF
--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -98,36 +98,17 @@ export const NATIVE = {
 
     if (getPlatform() === CordovaPlatformType.Android) {
       const headerString = JSON.stringify(header);
-
       const payloadString = JSON.stringify(payload);
-      let length = payloadString.length;
-      try {
-        length = await this._nativeCall('getStringBytesLength', payloadString);
-      } catch {
-        // The native call failed, we do nothing, we have payload.length as a fallback
-      }
+      const payloadType = payload.type ?? 'event';
 
-      const item = {
-        content_type: 'application/json',
-        length,
-        type: payload.type ?? 'event',
-      };
-
-      const itemString = JSON.stringify(item);
-
-      const envelopeString = `${headerString}\n${itemString}\n${payloadString}`;
-
-      return this._nativeCall('captureEnvelope', envelopeString);
+      return this._nativeCall('captureEnvelope', headerString, payloadString, payloadType);
     }
 
     // Serialize and remove any instances that will crash the native bridge such as Spans
     const serializedPayload = JSON.parse(JSON.stringify(payload));
 
     // The envelope item is created (and its length determined) on the iOS side of the native bridge.
-    return this._nativeCall('captureEnvelope', {
-      header,
-      payload: serializedPayload,
-    });
+    return this._nativeCall('captureEnvelope', header, serializedPayload);
   },
 
   /**


### PR DESCRIPTION
Gets rid of the extra call across the native bridge that we used to have when we package the payload on the JS side with `getStringBytesLength`.

Also splits the iOS call into 2 parameters rather than a single object.

## How I got here
Originally wanted to unify `captureEnvelope` across the native bridge into a single call with the same parameters, but on iOS it needed the payload as an `NSDictionary` to pass to `NSJSONSerialization dataWithJSONObject` to get an NSData to create an envelope item. Tried this on Android, sending the payload over as a `JSONObject` and converting it into a string with `toString()`, however that outputted all the timestamps in scientific notation in the output JSON string (`x.xxxxxE9`) which errors the envelope pipeline. Considered using Gson instead, but I figured the serialization and deserialization to convert the `JSONObject` to Gson would be needlessly heavy.