### PR TITLE
fix(ios): Handle auto session tracking start on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - build(ios): Bump `sentry-cocoa` to 6.2.1 (#205)
 - feat(android): Add Android native bridge, full scope sync, and cached events (#202)
 - feat: Set `event.origin` and `event.environment` tags (#204)
+- fix(ios): Handle auto session tracking start on iOS (#206)
 
 ## v1.0.0-rc.0
 

--- a/src/ios/SentryCordova.m
+++ b/src/ios/SentryCordova.m
@@ -2,7 +2,9 @@
 #import <Cordova/CDVAvailability.h>
 @import Sentry;
 
-@implementation SentryCordova
+@implementation SentryCordova {
+  bool sentHybridSdkDidBecomeActive;
+}
 
 - (void)pluginInitialize {
   NSLog(@"Sentry Cordova Plugin initialized");
@@ -32,6 +34,19 @@
                                  messageAsBool:NO];
   } else {
     [SentrySDK startWithOptionsObject:sentryOptions];
+
+    // If the app is active/in foreground, and we have not sent the
+    // SentryHybridSdkDidBecomeActive notification, send it.
+    if ([[UIApplication sharedApplication] applicationState] ==
+            UIApplicationStateActive &&
+        !sentHybridSdkDidBecomeActive &&
+        sentryOptions.enableAutoSessionTracking) {
+      [[NSNotificationCenter defaultCenter]
+          postNotificationName:@"SentryHybridSdkDidBecomeActive"
+                        object:nil];
+
+      sentHybridSdkDidBecomeActive = true;
+    }
   }
 
   [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];


### PR DESCRIPTION
Same as https://github.com/getsentry/sentry-react-native/pull/1308

Tested on iOS Simulator with sample app. With this, release health now works on the Cordova SDK for both iOS and Android. Browser will need a unique solution to use @sentry/browser's sessions while disabling it when running on native platforms. This will be added in a later version.