### PR TITLE
feat: Expose startTransaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - fix: Remove setRelease and setDist, have auto release passed to native #213
+- feat: Expose startTransaction #216
 
 ## v1.0.0-rc.1
 

--- a/src/js/sentry-cordova.ts
+++ b/src/js/sentry-cordova.ts
@@ -29,11 +29,13 @@ export {
   setExtras,
   setTag,
   setTags,
+  startTransaction,
   Hub,
   Scope,
 } from '@sentry/core';
 
 import { Integrations as BrowserIntegrations } from '@sentry/browser';
+
 export { CordovaBackend, CordovaOptions } from './backend';
 export { CordovaClient } from './client';
 export { init, nativeCrash } from './sdk';


### PR DESCRIPTION
Expose `startTransaction` to use with `@sentry/tracing`. You will be able to just add tracing as a dependency, import it, and use it as if on browser after this method is exposed.