### PR TITLE
Fix Mac M1 build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Fix build on Mac M1 ([#262](https://github.com/getsentry/sentry-cordova/pull/262))
 - Support for running with cordova-android 10 ([#246](https://github.com/getsentry/sentry-cordova/pull/246))
 
 ## v1.0.0

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 build:
-	cd src/ios; carthage update
+	cd src/ios; carthage update --use-xcframeworks; carthage build --use-xcframeworks --no-use-binaries

--- a/plugin.xml
+++ b/plugin.xml
@@ -58,7 +58,7 @@
 
         <!-- We don't have a resource-file here since this adds it to Xcode project -->
 
-        <framework src="src/ios/Carthage/Build/iOS/Sentry.framework" custom="true" embed="true" />
+        <framework src="src/ios/Carthage/Build/Sentry.xcframework" custom="true" embed="true" />
     </platform>
 
     <!-- browser -->


### PR DESCRIPTION
This PR fixes the build on M1 devices by adding an universal bundle to XCode where it's able to find the appropriate binaries for each target.

Close #252