### PR TITLE
Update .craft.yml

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -2,7 +2,7 @@
 github:
   owner: getsentry
   repo: sentry-cordova
-changelogPolicy: simple
+changelogPolicy: auto
 statusProvider:
   name: github
 artifactProvider:


### PR DESCRIPTION
- since the changelog format changed we need to update the craft rule
https://github.com/getsentry/craft#changelog-policies

#skip-changelog