### PR TITLE
dont exclude Sentry.xcframework from npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,6 @@
 *
 !/dist/**/*
-!/src/ios/Carthage/Build/iOS/**/*
+!/src/ios/Carthage/Build/Sentry.xcframework/**/*
 !/src/ios/SentryCordova.*
 !/src/android/**/*
 !/scripts/**/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Sentry.xcframework being excluded by npm rule ([#266](https://github.com/getsentry/sentry-cordova/pull/266))
+
 ## 1.0.1
 
 ### Fixes


### PR DESCRIPTION
This PR fixes the change where Sentry.xcframework was being excluded from the final package. One way to validate is to check if Sentry.xcframework is located on the generated artifact on the following path "src/ios/Carthage/Build/Sentry.xcframework"

Ideally we need some basic integration test to validate if the package is building :D 

Fixes #265