### PR TITLE
Check yarn.lock is dirty

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,9 +98,9 @@ jobs:
          if: steps.cache_built_packages.outputs.cache-hit == ''
          run: yarn build
         # yarn.lock cannot be dirty when releasing a new version.
-      - name: Check if yarn.lock is dirty
-        if: steps.cache_built_packages.outputs.cache-hit == ''
-        run: yarn install --frozen-lockfile
+       - name: Check if yarn.lock is dirty
+         if: steps.cache_built_packages.outputs.cache-hit == ''
+         run: yarn install --frozen-lockfile
 
      outputs:
        # this needs to be passed on, because the `needs` context only looks at direct ancestors (so steps which depend on

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,6 +97,10 @@ jobs:
          # this file) to a constant and skip rebuilding all of the packages each time CI runs.
          if: steps.cache_built_packages.outputs.cache-hit == ''
          run: yarn build
+        # yarn.lock cannot be dirty when releasing a new version.
+      - name: Check if yarn.lock is dirty
+        if: steps.cache_built_packages.outputs.cache-hit == ''
+        run: yarn install --frozen-lockfile
 
      outputs:
        # this needs to be passed on, because the `needs` context only looks at direct ancestors (so steps which depend on


### PR DESCRIPTION
Based on https://github.com/getsentry/sentry-capacitor/pull/213

The goal is to check if there aren't any missing changes that weren't pushed by the developer, if so, a release could get stalled because there are uncommitted changes on the main branch.

#skip-changelog