### PR TITLE
ref(ci): fix set-output / set-state deprecation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
          # so no need to reinstall them
        - name: Compute dependency cache key
          id: compute_lockfile_hash
-         run: echo "::set-output name=hash::${{ hashFiles('yarn.lock') }}"
+         run: echo "hash=${{ hashFiles('yarn.lock') }}" >> "$GITHUB_OUTPUT"
        - name: Check dependency cache
          uses: actions/cache@v2
          id: cache_dependencies


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Committed via https://github.com/asottile/all-repos

#skip-changelog