### PR TITLE
Fix version bump

### DIFF
--- a/scripts/versionbump.js
+++ b/scripts/versionbump.js
@@ -6,23 +6,28 @@ if (!newVersion || !newVersion.match(/\d+\.\d+.\d+(?:-\w+(?:\.\w+)?)?/)) {
   process.exit(1);
 }
 
+function ShowModifiedFiles(changedFiles) {
+  const files = changedFiles.map(item => item.file);
+  console.log('Modified files:', files.join(', '));
+}
+
 replace({
-  files: ['./src/ios/SentryCordova.m', './src/js/version.ts'],
+  files: ['./src/js/version.ts'],
   from: /\d+\.\d+.\d+(?:-\w+(?:\.\w+)?)?/g,
   to: newVersion,
 })
   .then(changedFiles => {
-    console.log('Modified files:', changedFiles.join(', '));
+    ShowModifiedFiles(changedFiles);
     return replace({
       files: ['plugin.xml'],
       // from: /id="@sentry\/cordova" version="\d+\.\d+.\d+"/g,
       // to: `id="@sentry/cordova" version="${pjson.version}"`,
-      from: /id="sentry-cordova" version="\d+\.\d+.\d+"/g,
+      from: /id="sentry-cordova" version="\d+.\d+.\d+[^"]*"/g,
       to: `id="sentry-cordova" version="${newVersion}"`,
     });
   })
   .then(changedFiles => {
-    console.log('Modified files:', changedFiles.join(', '));
+    ShowModifiedFiles(changedFiles);
   })
   .catch(error => {
     console.error('Error occurred:', error);


### PR DESCRIPTION
Version bump code was broken so this code is going to fix it : )

Fixes the following issues:

* Incorrect console output
- Before: Modified files: [object Object]
- After: Modified files: ./src/js/version.ts
* Removed parse of file that no longer has a fixed version number (SentryCordova.m)
* Fixed incorrect regex for plugin.xml and also refactored it to support it to handle cases where some developer adds any release candidate like string after the version:

Screenshots of regex maching the current version and a fictional version 1.2.3
<img width="518" alt="image" src="https://github.com/getsentry/sentry-cordova/assets/8229322/ac76c7c1-ccd1-4d72-96c8-9ea23265798c">
<img width="511" alt="image" src="https://github.com/getsentry/sentry-cordova/assets/8229322/d0a5df1c-ac9e-4843-8dce-4fae96468e02">

Fixes #306

#skip-changelog