### PR TITLE
Update .craft.yml

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -11,5 +11,8 @@ preReleaseCommand: bash scripts/craft-pre-release.sh
 targets:
   - name: npm
   - name: github
-  - name: registry
     tagPrefix: v
+  - name: registry
+    sdks:
+      npm:sentry-cordova:
+        includeNames: /none/

--- a/.craft.yml
+++ b/.craft.yml
@@ -11,4 +11,5 @@ preReleaseCommand: bash scripts/craft-pre-release.sh
 targets:
   - name: npm
   - name: github
+  - name: registry
     tagPrefix: v


### PR DESCRIPTION
The changes on this PR allows new releases to update the following link 
https://github.com/getsentry/sentry-release-registry/tree/master/packages/npm/sentry-cordova

- target `registry` allows you to publish to sentry-release-registry.
- `sdks` is the path to the publish folder `npm:sentry-cordova` is translated to `npm/sentry-cordova`
I am not entirely sure about the `includeNames` but I saw other repos from Sentry (Capacitor and React Native) using it so I just used the same value

#skip-changelog