### PR TITLE
Fix changelog pointing to wrong PR URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Sentry Replay Support ([#354](https://github.com/getsentry/sentry-wizard/pull/354))
+- Sentry Replay Support ([#354](https://github.com/getsentry/sentry-cordova/pull/354))
 
 How to use:
 
@@ -20,7 +20,7 @@ Replay, profiling and performance monitoring are bundled into Sentry Cordova, al
     integrations: [
       // Replay integration.
       Sentry.replayIntegration({
-        maskAllText: false,
+        maskAllText: true,
         blockAllMedia: true,
       }),
       // Tracing integration.
@@ -40,7 +40,7 @@ Replay, profiling and performance monitoring are bundled into Sentry Cordova, al
 - Bump Sentry JavaScript SDK to `7.119.1` ([#354](https://github.com/getsentry/sentry-cordova/pull/354))
   - [changelog](https://github.com/getsentry/sentry-javascript/releases/tag/7.119.1)
   - [diff](https://github.com/getsentry/sentry-javascript/compare/7.34.0...7.119.1)
-- Bump `sentry-wizard` to 3.32.0 ([#354](https://github.com/getsentry/sentry-wizard/pull/354))
+- Bump `sentry-wizard` to 3.32.0 ([#354](https://github.com/getsentry/sentry-cordova/pull/354))
 - Bump Android SDK from v7.6.0 to v7.14.0 ([#353](https://github.com/getsentry/sentry-cordova/pull/353))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#7140)
   - [diff](https://github.com/getsentry/sentry-java/compare/7.6.0...7.14.0)


### PR DESCRIPTION
The main branch contains wrong URLs pointing to a wizard PR where it should actually point to the cordova PR, this PR fixes that.

Also, I have changed the changelog parameter of maskAllText to true

#skip-changelog