### PR TITLE
internal: Ignore yarn cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,5 +74,8 @@ package-lock.json
 # Generated Lockfiles
 Cartfile.resolved
 
+# Yarn cache
+.yarn
+
 # Yalc
 sample/yalc.lock


### PR DESCRIPTION
with corepack enabled, the cache will be installed on folder .yarn, this PR ignores the .yarn folder

#skip-changelog.