### PR TITLE
fix(): Use workflow token instead of release PAT

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Build Cocoa SDK from Carthage
         if: steps.cache_built_carthage.outputs.cache-hit != 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: make build
 
   job_artifacts:


### PR DESCRIPTION
Related to #365, getting rid of GH_RELEASE_PAT usage, but it seems like a privileged token is not required here

#skip-changelog