### PR TITLE
Feat: Support for Debug ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Support for Debug ID ([#374](https://github.com/getsentry/sentry-cordova/pull/374))
+
 ## 1.4.1
 
 ### Dependencies

--- a/scripts/before_compile.js
+++ b/scripts/before_compile.js
@@ -131,17 +131,22 @@ module.exports = function (ctx) {
         fs.writeFileSync(projectRootIndexHtml, contents.replace(regex, replaceWith));
       }
 
-      console.log(`Uploading assets release: '${release}' path: ${buildPath}`);
-      return sentryCli.releases
-        .new(release)
-        .then(() =>
-          sentryCli.releases.uploadSourceMaps(release, {
-            include: includes,
-            ignore: ignore,
-            rewrite: true,
-          })
-        )
-        .then(() => sentryCli.releases.finalize(release));
+      console.log(`Injecting Debug ID on release: '${release}' path: ${buildPath}`);
+      return sentryCli.execute(['sourcemaps', 'inject', buildPath])
+        .then(() => {
+          console.log(`Uploading assets release: '${release}' path: ${buildPath}`);
+
+          return sentryCli.releases
+            .new(release)
+            .then(() =>
+              sentryCli.releases.uploadSourceMaps(release, {
+                include: includes,
+                ignore: ignore,
+                rewrite: true,
+              })
+            )
+            .then(() => sentryCli.releases.finalize(release));
+        });
     });
   });
 


### PR DESCRIPTION
This PR introduces a  change that when we automatically upload the release source maps, we also inject the Debuh ID, making it easier to link the sourcemap with the projects, without the need to have matching dists anymore.


Tested locally and validated on the server:
https://us.sentry.io/api/0/projects/sentry-sdks/sentry-cordova/events/33bd11062feb4bdcbe4203c223e43d16/json/

https://sentry-sdks.sentry.io/issues/6533969814/?project=5627302&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&stream_index=0