### PR TITLE
Fix symbolic links from Carthage

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "fix:eslint": "eslint . --format stylish --fix",
     "preversion:changelog": "grep -q -F \"## v$npm_package_version\" CHANGELOG.md",
     "version:all": "yarn run preversion:changelog && yarn run version:bump && yarn run test",
-    "version:bump": "node ./scripts/versionbump.js && git add -A"
+    "version:bump": "node ./scripts/versionbump.js && git add -A",
+    "prepack": "scripts/resolve-symlinks.sh"
   },
   "jest": {
     "testEnvironment": "jsdom",

--- a/scripts/resolve-symlinks.sh
+++ b/scripts/resolve-symlinks.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+BUILD_DIR="src/ios/Carthage/Build"
+
+if [ ! -d "$BUILD_DIR" ]; then
+  echo "⚠️  Build directory not found: $BUILD_DIR"
+  exit 1
+fi
+
+echo "🔧 Resolving symlinks in $BUILD_DIR..."
+
+TMP_DIR=$(mktemp -d)
+
+cp -R -L "$BUILD_DIR" "$TMP_DIR"
+rm -rf "$BUILD_DIR"
+mv "$TMP_DIR/Build" "$BUILD_DIR"
+rmdir "$TMP_DIR"
+
+echo "✅ Symlinks resolved successfully in $BUILD_DIR"


### PR DESCRIPTION
Lately the Carthage builds are introducing symbolic links, in order to fix it I added a script that runs before yarn publishes a package where it copies all symbolic link folders into their designated areas, removing the need of symbolic links and making the PR Build happy

#skip-changelog.