### PR TITLE
release: 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.6.0
 
 ### Fixes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-cordova",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "main": "dist/js/sentry-cordova.js",
   "types": "dist/js/sentry-cordova.d.ts",
   "license": "MIT",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="sentry-cordova" version="1.5.0">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="sentry-cordova" version="1.6.0">
     <name>Sentry</name>
     <author>Sentry</author>
     <description>Official Sentry SDK for Cordova</description>

--- a/src/js/version.ts
+++ b/src/js/version.ts
@@ -1,2 +1,2 @@
 export const SDK_NAME = 'sentry.javascript.cordova';
-export const SDK_VERSION = '1.5.0';
+export const SDK_VERSION = '1.6.0';


### PR DESCRIPTION
1.6.0 was released but it failed to release a new version.
This PR only syncs what was released on version 1.6.0 into main

#skip-changelog